### PR TITLE
fix: use expo-gl from separated module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GLView } from 'expo';
+import { GLView } from 'expo-gl';
 
 const Browser = require('processing-js/lib/Browser');
 Browser.window = window;


### PR DESCRIPTION
Fixes #2

Maybe it's nice to have `expo-gl` listed as peer dependency with `*`? Not sure if its necessary, but it's nice to have a warning if you forgot that one 😄 